### PR TITLE
fix: preserve JSON-LD site evidence

### DIFF
--- a/src/keywords/site-evidence.ts
+++ b/src/keywords/site-evidence.ts
@@ -78,7 +78,7 @@ function splitKeywords(value: string): string[] {
 
 function jsonLdScripts(html: string): unknown[] {
   const rows: unknown[] = [];
-  for (const match of html.matchAll(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)) {
+  for (const match of html.matchAll(/<script\b[^>]*\btype\s*=\s*(?:"application\/ld\+json"|'application\/ld\+json'|application\/ld\+json(?=[\s>]))[^>]*>([\s\S]*?)<\/script>/gi)) {
     const raw = decodeEntities((match[1] || "").trim());
     if (!raw) continue;
     try {

--- a/test/site-evidence.test.ts
+++ b/test/site-evidence.test.ts
@@ -35,3 +35,12 @@ test("collects JSON-LD before stripping ordinary scripts from page text", () => 
   assert.deepEqual(page.jsonLdKeywords, ["AI agent audit", "token usage evidence"]);
   assert.equal(page.textSnippet?.includes("this should not appear in the text snippet"), false);
 });
+
+test("accepts valid unquoted JSON-LD type attributes", () => {
+  const page = extractSiteEvidencePage({
+    url: "https://example.dev/",
+    html: `<script TYPE = application/ld+json>{"name":"Unquoted metadata"}</script>`,
+  });
+
+  assert.deepEqual(page.jsonLdNames, ["Unquoted metadata"]);
+});


### PR DESCRIPTION
This is a small follow-up to #9.

The basic JSON-LD ordering fix landed in `main` while this PR was being prepared. This branch is now based on the latest `main` and adds support for valid unquoted `type=application/ld+json` attributes, which some HTML serializers produce.

There is also a regression test for the unquoted form.

Fixes #9