### PR TITLE
Fix duplicate citation URL counting

### DIFF
--- a/src/providers/citation-extractors.ts
+++ b/src/providers/citation-extractors.ts
@@ -31,7 +31,7 @@ export function dedupeCitations(citations: Citation[]): Citation[] {
   const seen = new Set<string>();
   const out: Citation[] = [];
   for (const citation of citations) {
-    const key = `${citation.source}:${citation.url}`;
+    const key = citation.url;
     if (seen.has(key)) continue;
     seen.add(key);
     out.push({ ...citation, citationIndex: out.length });

--- a/test/citation-extractors.test.ts
+++ b/test/citation-extractors.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { dedupeCitations } from "../src/providers/citation-extractors.js";
+
+test("deduplicates the same URL across citation sources", () => {
+  const citations = dedupeCitations([
+    {
+      id: "native",
+      url: "https://example.com/docs",
+      domain: "example.com",
+      citationIndex: 0,
+      source: "provider_annotation",
+      citationType: "unknown",
+    },
+    {
+      id: "text",
+      url: "https://example.com/docs",
+      domain: "example.com",
+      citationIndex: 1,
+      source: "answer_text_url",
+      citationType: "unknown",
+    },
+  ]);
+
+  assert.equal(citations.length, 1);
+  assert.equal(citations[0]?.source, "provider_annotation");
+  assert.equal(citations[0]?.citationIndex, 0);
+});


### PR DESCRIPTION
## What changed?

Deduplicate citations by canonical URL instead of by `source + URL`. This prevents one page from being counted twice when a provider returns it as a native citation and the answer text also contains the same link.

## Why?

Citation counts and citation rate should reflect distinct cited pages. Keeping the first entry also preserves the richer provider citation metadata when a text URL duplicates it.

## Testing

- `npm test`
- 22 tests passed

## Scope

- Closes #12
- No provider request format or report layout changes.