### PR TITLE
Continue audits when one provider key is missing

### DIFF
--- a/src/runner/audit-planner.ts
+++ b/src/runner/audit-planner.ts
@@ -9,7 +9,7 @@ import type {
   ProviderTarget,
 } from "../core/types.js";
 import { ANALYSIS_RULES_VERSION, PROMPT_SET_VERSION } from "../core/version.js";
-import { resolveProviderKey, runsDir } from "../config/env.js";
+import { hasProviderKey, resolveProviderKey, runsDir } from "../config/env.js";
 import { ProviderCatalog } from "../providers/catalog.js";
 import { PromptGenerator, promptsFromManual } from "../prompts/prompt-generator.js";
 import { DomainProfiler } from "../profile/domain-profiler.js";
@@ -130,11 +130,11 @@ export class AuditPlanner {
     const store = new FileStore(input.runsRoot || runsDir());
     const firstTarget = input.providerTargets[0];
     if (!firstTarget) throw new Error("At least one provider target is required.");
-    const firstProvider = this.catalog.get(firstTarget.providerId);
-    const firstApiKey = resolveProviderKey(firstTarget.providerId);
-    const profileTarget = selectProfileTarget(input.providerTargets);
+    const availableTargets = input.providerTargets.filter((target) => hasProviderKey(target.providerId));
+    const promptTarget = availableTargets[0] || firstTarget;
+    const firstProvider = this.catalog.get(promptTarget.providerId);
+    const profileTarget = selectProfileTarget(availableTargets.length ? availableTargets : input.providerTargets);
     const profileProvider = this.catalog.get(profileTarget.providerId);
-    const profileApiKey = resolveProviderKey(profileTarget.providerId);
 
     let effectiveTarget = input.target;
     let effectiveCompetitors = input.competitors;
@@ -142,7 +142,8 @@ export class AuditPlanner {
     let discoveryEvidence: AuditPlan["discoveryEvidence"];
     let discoveredPrompts: MonitoringPrompt[] = [];
 
-    if (input.autoDiscover) {
+    if (input.autoDiscover && hasProviderKey(profileTarget.providerId)) {
+      const profileApiKey = resolveProviderKey(profileTarget.providerId);
       const discovered = await this.domainProfiler.discover({
         auditId: planId,
         domain: input.submittedDomain || input.target.domain,
@@ -232,8 +233,8 @@ export class AuditPlanner {
         language: input.language,
         count: input.promptCount,
         provider: firstProvider,
-        model: firstTarget.model,
-        apiKey: firstApiKey,
+        model: promptTarget.model,
+        apiKey: resolveProviderKey(promptTarget.providerId),
         store,
       });
       generatedPrompts = generated.prompts;

--- a/src/runner/audit-runner.ts
+++ b/src/runner/audit-runner.ts
@@ -13,7 +13,7 @@ import type {
   PromptRun,
   ReportBundle,
 } from "../core/types.js";
-import { resolveProviderKey, runsDir } from "../config/env.js";
+import { hasProviderKey, resolveProviderKey, runsDir } from "../config/env.js";
 import { ProviderCatalog } from "../providers/catalog.js";
 import { PromptGenerator, promptsFromManual } from "../prompts/prompt-generator.js";
 import { buildExecutionPrompt } from "../prompts/execution-prompt.js";
@@ -177,11 +177,12 @@ export class AuditRunner {
 
     const firstTarget = providerTargets[0];
     if (!firstTarget) throw new Error("At least one provider target is required.");
-    const profileTarget = selectProfileTarget(providerTargets);
+    const availableTargets = providerTargets.filter((target) => hasProviderKey(target.providerId));
+    const promptTarget = availableTargets[0] || firstTarget;
+    const profileTarget = selectProfileTarget(availableTargets.length ? availableTargets : providerTargets);
     const profileProvider = this.catalog.get(profileTarget.providerId);
-    const profileApiKey = resolveProviderKey(profileTarget.providerId);
-    const firstProvider = this.catalog.get(firstTarget.providerId);
-    const firstApiKey = resolveProviderKey(firstTarget.providerId);
+    const firstProvider = this.catalog.get(promptTarget.providerId);
+    let profileApiKey: string | undefined;
 
     let effectiveTarget = input.target;
     let effectiveCompetitors = input.competitors;
@@ -208,7 +209,8 @@ export class AuditRunner {
         evidence: input.confirmedPlan.promptGeneration,
       };
     } else {
-      if (input.autoDiscover) {
+      if (input.autoDiscover && hasProviderKey(profileTarget.providerId)) {
+        profileApiKey = resolveProviderKey(profileTarget.providerId);
         const discovered = await this.domainProfiler.discover({
           auditId,
           domain: input.submittedDomain || input.target.domain,
@@ -306,8 +308,8 @@ export class AuditRunner {
                 language: input.language,
                 count: input.promptCount,
                 provider: firstProvider,
-                model: firstTarget.model,
-                apiKey: firstApiKey,
+                model: promptTarget.model,
+                apiKey: resolveProviderKey(promptTarget.providerId),
                 store,
               });
     }
@@ -326,15 +328,21 @@ export class AuditRunner {
       }),
     );
 
-    const discoveredCompetitors = await this.discoverCompetitorsFromAnswers({
-      target: effectiveTarget,
-      existingCompetitors: effectiveCompetitors,
-      runs,
-      language: input.language,
-      provider: profileProvider,
-      model: profileTarget.model,
-      apiKey: profileApiKey,
-    });
+    let discoveredCompetitors: DiscoveredCompetitor[] = [];
+    try {
+      const apiKey = profileApiKey || resolveProviderKey(profileTarget.providerId);
+      discoveredCompetitors = await this.discoverCompetitorsFromAnswers({
+        target: effectiveTarget,
+        existingCompetitors: effectiveCompetitors,
+        runs,
+        language: input.language,
+        provider: profileProvider,
+        model: profileTarget.model,
+        apiKey,
+      });
+    } catch {
+      discoveredCompetitors = [];
+    }
     const mergedCompetitors = mergeDiscoveredCompetitors({
       target: effectiveTarget,
       existing: effectiveCompetitors,
@@ -391,7 +399,6 @@ export class AuditRunner {
   }): Promise<PromptRun> {
     const { prompt, providerTarget } = input.task;
     const provider = this.catalog.get(providerTarget.providerId);
-    const apiKey = resolveProviderKey(providerTarget.providerId);
     const id = runId(prompt, providerTarget);
     const runStartedAt = new Date().toISOString();
     const executionPrompt = buildExecutionPrompt(prompt);
@@ -412,6 +419,7 @@ export class AuditRunner {
     };
 
     try {
+      const apiKey = resolveProviderKey(providerTarget.providerId);
       const result = await provider.run({
         prompt: executionPrompt,
         model: providerTarget.model,

--- a/test/provider-key-failures.test.ts
+++ b/test/provider-key-failures.test.ts
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { AnswerProvider, AnswerResult, MonitoringPrompt, ProviderDefinition } from "../src/core/types.js";
+import { AuditPlanner } from "../src/runner/audit-planner.js";
+import { AuditRunner } from "../src/runner/audit-runner.js";
+import { entityFromInput } from "../src/utils/domain.js";
+
+function definition(id: string): ProviderDefinition {
+  return {
+    id,
+    label: id,
+    sourceType: "api",
+    envKeys: [`${id.toUpperCase()}_API_KEY`],
+    defaultModels: ["test-model"],
+    supportsNativeCitations: false,
+    supportsWebSearch: false,
+    resultCaveat: "test",
+  };
+}
+
+function result(providerId: string): AnswerResult {
+  return {
+    providerId,
+    providerName: providerId,
+    sourceType: "api",
+    sourceLabel: `Source: ${providerId} API`,
+    resultCaveat: "test",
+    model: "test-model",
+    modelVersion: "test-model",
+    text: "A test answer.",
+    rawJson: null,
+    citations: [],
+    webQueries: [],
+    latencyMs: 1,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function fakeProvider(id: string): AnswerProvider {
+  return {
+    definition: definition(id),
+    async run() {
+      return result(id);
+    },
+  };
+}
+
+test("planner accepts manual prompts when none of the selected providers has a key", async () => {
+  const target = entityFromInput({ type: "target", domain: "example.com", name: "Example" });
+  const plan = await new AuditPlanner().plan({
+    target,
+    competitors: [],
+    providerTargets: [
+      { providerId: "openai", model: "gpt-4o-mini" },
+      { providerId: "gemini", model: "gemini-1.5-flash" },
+    ],
+    language: "en",
+    promptCount: 1,
+    manualPrompts: ["What should I use for this need?"],
+    autoDiscover: false,
+  });
+
+  assert.equal(plan.prompts.length, 1);
+  assert.equal(plan.estimate.providerRunCount, 2);
+});
+
+test("a missing key fails only that provider run", async () => {
+  const previousOpenAiKey = process.env.OPENAI_API_KEY;
+  const previousGeminiKey = process.env.GEMINI_API_KEY;
+  process.env.OPENAI_API_KEY = "test-key";
+  delete process.env.GEMINI_API_KEY;
+
+  try {
+    const runner = new AuditRunner();
+    const internal = runner as unknown as {
+      catalog: { get: (id: string) => AnswerProvider; validate: (id: string, model: string) => void };
+      executeProviderRun: (input: {
+        task: { prompt: MonitoringPrompt; providerTarget: { providerId: string; model: string } };
+        target: ReturnType<typeof entityFromInput>;
+        competitors: ReturnType<typeof entityFromInput>[];
+        maxTokens: number;
+        temperature: number;
+      }) => Promise<{ status: string; providerId: string; error?: string }>;
+    };
+    internal.catalog.get = (id: string) => fakeProvider(id);
+    internal.catalog.validate = () => undefined;
+    const target = entityFromInput({ type: "target", domain: "example.com", name: "Example" });
+    const prompt: MonitoringPrompt = {
+      id: "manual-example-1",
+      type: "category",
+      topic: "manual",
+      language: "en",
+      text: "What should I use for this need?",
+      enabled: true,
+    };
+
+    const [available, missing] = await Promise.all([
+      internal.executeProviderRun({
+        task: { prompt, providerTarget: { providerId: "openai", model: "test-model" } },
+        target,
+        competitors: [],
+        maxTokens: 100,
+        temperature: 0,
+      }),
+      internal.executeProviderRun({
+        task: { prompt, providerTarget: { providerId: "gemini", model: "test-model" } },
+        target,
+        competitors: [],
+        maxTokens: 100,
+        temperature: 0,
+      }),
+    ]);
+
+    assert.equal(available.status, "completed");
+    assert.equal(missing.status, "failed");
+    assert.match(missing.error || "", /Missing API key for provider "gemini"/);
+  } finally {
+    if (previousOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousOpenAiKey;
+    if (previousGeminiKey === undefined) delete process.env.GEMINI_API_KEY;
+    else process.env.GEMINI_API_KEY = previousGeminiKey;
+  }
+});


### PR DESCRIPTION
## What changed?

Keep audit planning and execution usable when multiple providers are selected but only some provider keys are configured.

- Use an available provider for profile and prompt generation when possible.
- Skip automatic discovery when no provider key is available instead of failing during planning.
- Resolve each provider key inside its own run so a missing key produces a failed run for that provider only.
- Preserve the existing behavior when no selected provider has a key: the run remains clearly unavailable rather than making an unauthenticated request.

## Why?

A missing key for the first listed provider should not prevent another configured provider from running. This is particularly important for manual prompts with auto-discovery disabled.

## Testing

- `npm test`
- 23 tests passed
- Added coverage for planning without any selected provider key and for isolating a missing key to one provider run.

## Scope

- Closes #14
- No provider request format changes.