### PR TITLE
Match GitHub citations to the exact repository

### DIFF
--- a/src/analyzer/citation-intelligence.ts
+++ b/src/analyzer/citation-intelligence.ts
@@ -1,5 +1,18 @@
 import type { Citation, CitationDomainGroup, Entity } from "../core/types.js";
-import { domainMatches, extractDomainFromUrl } from "../utils/domain.js";
+import { domainMatches, extractDomainFromUrl, githubRepoSlug } from "../utils/domain.js";
+
+function isTargetGithubRepo(url: string, githubRepo: string | undefined): boolean {
+  const repo = githubRepoSlug(githubRepo || "");
+  if (!repo) return false;
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.toLowerCase() !== "github.com") return false;
+    const pathRepo = parsed.pathname.replace(/^\/+|\/+$/g, "");
+    return pathRepo.toLowerCase() === repo.toLowerCase();
+  } catch {
+    return false;
+  }
+}
 
 export function attachCitationTypes(citations: Citation[], target: Entity, competitors: Entity[]): Citation[] {
   return citations.map((citation) => {
@@ -15,7 +28,7 @@ export function attachCitationTypes(citations: Citation[], target: Entity, compe
       };
     }
 
-    if (target.githubRepo && citation.url.toLowerCase().includes(`github.com/${target.githubRepo.toLowerCase()}`)) {
+    if (isTargetGithubRepo(citation.url, target.githubRepo)) {
       return {
         ...citation,
         domain,

--- a/test/analyzer.test.ts
+++ b/test/analyzer.test.ts
@@ -92,3 +92,40 @@ test("classifies sentiment from the entity sentence instead of a broad paragraph
   assert.equal(competitorMention?.sentiment, "neutral");
   assert.notEqual(competitorMention?.mentionType, "negative");
 });
+
+test("matches only the exact target GitHub repository path", () => {
+  const target = entityFromInput({ type: "target", domain: "example.com", name: "Demo", githubRepo: "foo/bar" });
+  const exact = new ResponseAnalyzer().analyze({
+    target,
+    competitors: [],
+    text: "See the project.",
+    citations: [
+      {
+        id: "exact",
+        url: "https://github.com/foo/bar/",
+        domain: "github.com",
+        citationIndex: 0,
+        source: "answer_text_url",
+        citationType: "unknown",
+      },
+    ],
+  });
+  assert.equal(exact.citations[0]?.citationType, "target_github");
+
+  const unrelated = new ResponseAnalyzer().analyze({
+    target,
+    competitors: [],
+    text: "See another project.",
+    citations: [
+      {
+        id: "unrelated",
+        url: "https://github.com/foo/barista",
+        domain: "github.com",
+        citationIndex: 0,
+        source: "answer_text_url",
+        citationType: "unknown",
+      },
+    ],
+  });
+  assert.equal(unrelated.citations[0]?.citationType, "third_party");
+});


### PR DESCRIPTION
## What changed?

Match GitHub citations against the exact configured `owner/repository` path instead of using a substring check.

- Exact repository URLs are classified as `target_github`.
- Repository subpages such as `/issues/1` and `/releases` remain associated with the repository.
- Similar repository names with the same prefix remain third-party citations.

## Why?

A repository such as `foo/barista` should not be counted as a citation for the configured repository `foo/bar`. The previous substring check could inflate official citation metrics and make the report misleading.

## Testing

- `npm test`
- 22 tests passed
- Added regression coverage for exact and same-prefix repository URLs.

## Scope

- Closes #16
- No provider request or report layout changes.