### PR TITLE
Distinguish requested and confirmed web search

### DIFF
--- a/docs/PROVIDER_NATIVE_SEARCH.md
+++ b/docs/PROVIDER_NATIVE_SEARCH.md
@@ -44,8 +44,8 @@ Each completed run can store:
 {
   "requested": true,
   "requestMode": "auto",
-  "used": true,
-  "usedMode": "provider_native",
+  "used": false,
+  "usedMode": "requested_not_confirmed",
   "endpointKind": "official_api",
   "endpointProtocol": "responses",
   "endpointUrl": "https://api.openai.com/v1/responses",
@@ -55,4 +55,6 @@ Each completed run can store:
 }
 ```
 
-This metadata is for source transparency. The user-facing report should still explain it in plain language such as `No web search`, `Provider-native web search`, or `Provider web-grounded`.
+`requested` means the provider-native search option was sent. `used` is true only when the response contains search evidence, except for providers that are always web-grounded such as Perplexity. If a provider accepts the option but returns no search evidence, the report shows `Search unconfirmed`.
+
+This metadata is for source transparency. The user-facing report should explain the distinction in plain language such as `No web search`, `Search unconfirmed`, `Provider-native web search`, or `Provider web-grounded`.

--- a/docs/PROVIDER_NATIVE_SEARCH.zh-CN.md
+++ b/docs/PROVIDER_NATIVE_SEARCH.zh-CN.md
@@ -44,8 +44,8 @@ NiubiGEO 把联网能力放在 Provider 执行层，而不是报告展示层。
 {
   "requested": true,
   "requestMode": "auto",
-  "used": true,
-  "usedMode": "provider_native",
+  "used": false,
+  "usedMode": "requested_not_confirmed",
   "endpointKind": "official_api",
   "endpointProtocol": "responses",
   "endpointUrl": "https://api.openai.com/v1/responses",
@@ -55,4 +55,6 @@ NiubiGEO 把联网能力放在 Provider 执行层，而不是报告展示层。
 }
 ```
 
-这些字段用于来源透明。用户报告里仍然只用普通语言展示，例如“未联网”“Provider 原生联网”或“Provider 天然联网”。
+`requested` 表示请求中发送了 Provider 原生搜索选项；`used` 只有在响应中出现搜索证据时才为 `true`。Perplexity 这类天然联网的 Provider 例外处理。如果 Provider 接受了搜索选项，但响应中没有搜索查询或原生引用，报告会显示“联网未确认”。
+
+这些字段用于来源透明。用户报告里会区分“未联网”“联网未确认”“Provider 原生联网”和“Provider 天然联网”。

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -48,7 +48,7 @@ export type CitationSource =
 
 export type WebSearchRequestMode = "auto" | "provider_native";
 
-export type WebSearchUsedMode = "none" | "provider_native" | "provider_always_on";
+export type WebSearchUsedMode = "none" | "requested_not_confirmed" | "provider_native" | "provider_always_on";
 
 export type ProviderEndpointKind = "official_api" | "custom_gateway";
 

--- a/src/providers/search-execution.ts
+++ b/src/providers/search-execution.ts
@@ -34,9 +34,16 @@ export function makeSearchExecution(input: {
   const requested = Boolean(input.runInput.webSearchEnabled);
   const requestMode = input.runInput.webSearchMode || "auto";
   const alwaysOn = Boolean(input.alwaysOn);
-  const used = requested || alwaysOn;
-  const usedMode: WebSearchUsedMode = used ? (alwaysOn && !requested ? "provider_always_on" : "provider_native") : "none";
   const webQueries = uniqueStrings(input.webQueries || []);
+  const hasExecutionEvidence = webQueries.length > 0 || (input.citationCount || 0) > 0;
+  const used = alwaysOn || (requested && hasExecutionEvidence);
+  const usedMode: WebSearchUsedMode = alwaysOn && !requested
+    ? "provider_always_on"
+    : used
+      ? "provider_native"
+      : requested
+        ? "requested_not_confirmed"
+        : "none";
   return {
     requested,
     requestMode,
@@ -45,9 +52,9 @@ export function makeSearchExecution(input: {
     endpointKind: input.endpointKind,
     endpointProtocol: input.endpointProtocol,
     endpointUrl: input.endpointUrl,
-    toolName: used ? input.toolName : undefined,
+    toolName: requested || alwaysOn ? input.toolName : undefined,
     webQueries,
-    citationCount: used ? input.citationCount || 0 : 0,
+    citationCount: input.citationCount || 0,
     note: input.note,
   };
 }

--- a/src/report/human-report.ts
+++ b/src/report/human-report.ts
@@ -300,7 +300,10 @@ function sourceName(run: PromptRun): string {
 
 function searchSummary(run: PromptRun, locale: HumanReportLocale): string {
   const search = run.search || run.result?.search;
-  if (!search?.used) return fallback(locale, "未联网", "No web search");
+  if (!search?.used) {
+    if (search?.requested) return fallback(locale, "联网未确认", "Search unconfirmed");
+    return fallback(locale, "未联网", "No web search");
+  }
   if (search.usedMode === "provider_always_on") return fallback(locale, "Provider 天然联网", "Provider web-grounded");
   return fallback(locale, "Provider 原生联网", "Provider-native web search");
 }

--- a/test/native-web-search.test.ts
+++ b/test/native-web-search.test.ts
@@ -71,7 +71,7 @@ test("OpenRouter sends its web plugin only when web search is enabled", async ()
   mockFetch(
     {
       model: "openai/gpt-4o-mini",
-      choices: [{ message: { content: "NiubiGEO is mentioned.", annotations: [] } }],
+      choices: [{ message: { content: "NiubiGEO is mentioned.", annotations: [{ url: "https://niubigeo.ai/", title: "NiubiGEO" }] } }],
       usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
     },
     captured,
@@ -94,6 +94,33 @@ test("OpenRouter sends its web plugin only when web search is enabled", async ()
   assert.deepEqual(onPlugins, [{ id: "web" }]);
   assert.equal(result.search?.usedMode, "provider_native");
   assert.equal(result.search?.toolName, "openrouter:web");
+});
+
+test("does not report optional web search as used without response evidence", async () => {
+  const captured: CapturedRequest[] = [];
+  mockFetch(
+    {
+      model: "openai/gpt-4o-mini",
+      choices: [{ message: { content: "NiubiGEO is mentioned.", annotations: [] } }],
+      usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+    },
+    captured,
+  );
+  const provider = new OpenAICompatibleProvider({
+    definition: definition("openrouter", "OpenRouter"),
+    endpoint: "https://openrouter.ai/api/v1/chat/completions",
+    nativeWebSearch: {
+      toolName: "openrouter:web",
+      bodyPatch: { plugins: [{ id: "web" }] },
+    },
+  });
+
+  const result = await provider.run(input({ webSearchEnabled: true }));
+
+  assert.deepEqual(captured[0]?.body.plugins, [{ id: "web" }]);
+  assert.equal(result.search?.requested, true);
+  assert.equal(result.search?.used, false);
+  assert.equal(result.search?.usedMode, "requested_not_confirmed");
 });
 
 test("OpenAI-compatible provider can request JSON object output for analyzer calls", async () => {

--- a/test/report-quality.test.ts
+++ b/test/report-quality.test.ts
@@ -7,6 +7,7 @@ import { GeoGapAnalyzer } from "../src/insights/gap-analyzer.js";
 import { ReportBuilder } from "../src/report/report-builder.js";
 import { ReportModelBuilder } from "../src/report/report-model.js";
 import { validateReport } from "../src/report/report-quality.js";
+import { buildHumanReport } from "../src/report/human-report.js";
 
 const target = entityFromInput({ type: "target", domain: "vercel.com", name: "Vercel" });
 const competitor = entityFromInput({ type: "competitor", domain: "netlify.com", name: "Netlify" });
@@ -246,4 +247,26 @@ test("Chinese audit report renders user-facing Chinese sections and actual answe
   assert.equal(html.includes("技术证据"), false);
   assert.equal(html.includes("原始 JSON"), false);
   assert.equal(html.includes("提及率"), false);
+});
+
+test("report distinguishes requested web search from confirmed execution", () => {
+  const run = makeRun({
+    webSearchEnabled: false,
+    search: {
+      requested: true,
+      requestMode: "auto",
+      used: false,
+      usedMode: "requested_not_confirmed",
+      endpointKind: "official_api",
+      endpointProtocol: "chat_completions",
+      endpointUrl: "https://openrouter.ai/api/v1/chat/completions",
+      toolName: "openrouter:web",
+      webQueries: [],
+      citationCount: 0,
+    },
+  });
+
+  const report = buildHumanReport(buildAudit(run));
+
+  assert.equal(report.sections.answers[0]?.webSearch, "Search unconfirmed");
 });


### PR DESCRIPTION
Closes #18

This keeps a requested web-search tool separate from confirmed search execution.

- Treat optional search as used only when the provider response includes a search query or native citation.
- Preserve the request in search metadata with `requested_not_confirmed` when no execution evidence is returned.
- Show the concise report status `联网未确认` / `Search unconfirmed` instead of claiming provider-native search ran.
- Keep always-web-grounded providers such as Perplexity Sonar unchanged.

Tests:

- `npm test` (38 passing)