### PR TITLE
Fix short brand name matching in prompt targeting

### DIFF
--- a/src/prompts/prompt-generator.ts
+++ b/src/prompts/prompt-generator.ts
@@ -1,5 +1,6 @@
 import type { AnswerProvider, Entity, MonitoringPrompt, PromptGenerationEvidence, PromptType } from "../core/types.js";
 import { FileStore } from "../store/file-store.js";
+import { containsTextTerm } from "../utils/text-match.js";
 import { withAuditCategory } from "./audit-category.js";
 
 interface GeneratedPromptRow {
@@ -80,11 +81,7 @@ export function promptsFromManual(input: { target: Entity; language: string; pro
 }
 
 export function promptContainsTarget(prompt: string, target: Entity): boolean {
-  const lower = prompt.toLowerCase();
-  return [target.name, target.domain, ...target.aliases].some((term) => {
-    const normalized = term.trim().toLowerCase();
-    return normalized.length > 0 && lower.includes(normalized);
-  });
+  return [target.name, target.domain, ...target.aliases].some((term) => containsTextTerm(prompt, term));
 }
 
 function hasAny(value: string, terms: string[]): boolean {

--- a/src/runner/audit-planner.ts
+++ b/src/runner/audit-planner.ts
@@ -16,6 +16,7 @@ import { DomainProfiler } from "../profile/domain-profiler.js";
 import { FileStore } from "../store/file-store.js";
 import { slugify } from "../utils/domain.js";
 import { sha256 } from "../utils/hash.js";
+import { containsTextTerm } from "../utils/text-match.js";
 import { SiteEvidenceCollector } from "../keywords/site-evidence.js";
 import { KeywordUniverseBuilder } from "../keywords/keyword-universe.js";
 import { KeywordRelevanceScorer } from "../keywords/keyword-relevance.js";
@@ -97,7 +98,7 @@ function dedupePrompts(prompts: MonitoringPrompt[], target: Entity): MonitoringP
           [target.name, target.domain, ...target.aliases]
             .map((term) => term.trim().toLowerCase())
             .filter(Boolean)
-            .some((term) => text.toLowerCase().includes(term)),
+            .some((term) => containsTextTerm(text, term)),
       }),
     );
   }

--- a/src/ui/app-html.ts
+++ b/src/ui/app-html.ts
@@ -908,11 +908,17 @@ export function renderAppHtml(): string {
     }
 
     function promptContainsTarget(text, target) {
-      const haystack = String(text || "").toLowerCase();
+      const value = String(text || "");
       const terms = [target?.name, target?.domain].concat(target?.aliases || [])
-        .map((term) => String(term || "").trim().toLowerCase())
+        .map((term) => String(term || "").trim())
         .filter(Boolean);
-      return terms.some((term) => haystack.includes(term));
+      return terms.some((term) => {
+        if (!/^[\\x00-\\x7F]+$/.test(term) || !/[A-Za-z0-9]/.test(term)) {
+          return value.toLowerCase().includes(term.toLowerCase());
+        }
+        const escaped = term.replace(/[.*+?^\${}()|[\\]\\\\]/g, "\\\\$&");
+        return new RegExp("(?<![A-Za-z0-9])" + escaped + "(?![A-Za-z0-9])", "i").test(value);
+      });
     }
 
     function planCounts(plan) {

--- a/src/utils/text-match.ts
+++ b/src/utils/text-match.ts
@@ -1,0 +1,18 @@
+function isAsciiWordTerm(value: string): boolean {
+  return /^[\x00-\x7F]+$/.test(value) && /[A-Za-z0-9]/.test(value);
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Match Latin brand names as terms, while keeping CJK matching substring-based. */
+export function containsTextTerm(text: string, term: string): boolean {
+  const normalizedTerm = term.trim();
+  if (!normalizedTerm) return false;
+  if (!isAsciiWordTerm(normalizedTerm)) {
+    return text.toLowerCase().includes(normalizedTerm.toLowerCase());
+  }
+  const pattern = new RegExp(`(?<![A-Za-z0-9])${escapeRegex(normalizedTerm)}(?![A-Za-z0-9])`, "i");
+  return pattern.test(text);
+}

--- a/test/domain-prompt-planner.test.ts
+++ b/test/domain-prompt-planner.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { DomainProfile } from "../src/core/types.js";
 import { DomainPromptPlanner } from "../src/prompts/domain-prompt-planner.js";
 import { entityFromInput } from "../src/utils/domain.js";
+import { promptContainsTarget } from "../src/prompts/prompt-generator.js";
 
 test("builds a mixed NiubiStar prompt plan with organic unbranded prompts", () => {
   const target = entityFromInput({ type: "target", domain: "www.niubistar.com", name: "NiubiStar" });
@@ -31,4 +32,12 @@ test("builds a mixed NiubiStar prompt plan with organic unbranded prompts", () =
   assert.ok(prompts.some((prompt) => prompt.targetIncluded === true));
   assert.ok(prompts.filter((prompt) => prompt.targetIncluded === false).length >= 3);
   assert.ok(prompts.some((prompt) => prompt.type === "comparison"));
+});
+
+test("matches short Latin brand names as standalone terms", () => {
+  const target = entityFromInput({ type: "target", domain: "go.dev", name: "Go" });
+
+  assert.equal(promptContainsTarget("What is a good deployment tool?", target), false);
+  assert.equal(promptContainsTarget("Should I use Go for deployment?", target), true);
+  assert.equal(promptContainsTarget("有哪些适合示例的工具？", entityFromInput({ type: "target", domain: "example.com", name: "示例" })), true);
 });


### PR DESCRIPTION
## Summary

- match Latin brand names as standalone terms when classifying prompt targeting
- keep substring matching for CJK names
- apply the same rule in the planner fallback and the browser prompt editor
- add regression coverage for the `Go` / `good` false positive

Fixes #20

## Validation

- `npm test` (39 passing)
