### PR TITLE
修复结构化空回答被截断时无法触发认知重试

### DIFF
--- a/docs/PROVIDER_NATIVE_SEARCH.md
+++ b/docs/PROVIDER_NATIVE_SEARCH.md
@@ -58,3 +58,9 @@ Each completed run can store:
 `requested` means the provider-native search option was sent. `used` is true only when the response contains search evidence, except for providers that are always web-grounded such as Perplexity. If a provider accepts the option but returns no search evidence, the report shows `Search unconfirmed`.
 
 This metadata is for source transparency. The user-facing report should explain the distinction in plain language such as `No web search`, `Search unconfirmed`, `Provider-native web search`, or `Provider web-grounded`.
+
+## Empty token-limited structured responses
+
+The Chat Completions adapter preserves an empty JSON-schema response when the provider reports `finish_reason: length`, including the raw response, usage, cost, and search metadata. Recognition processing can then use its existing bounded recovery: one retry from 900 to 2000 output tokens. A second empty response remains an analysis failure; other empty responses still raise `empty_answer`.
+
+This does not substitute reasoning text for an answer or fabricate citations. OpenRouter requests continue to use only the OpenRouter key and retain `Source: OpenRouter API` labeling.

--- a/docs/PROVIDER_NATIVE_SEARCH.md
+++ b/docs/PROVIDER_NATIVE_SEARCH.md
@@ -61,6 +61,6 @@ This metadata is for source transparency. The user-facing report should explain 
 
 ## Empty token-limited structured responses
 
-The Chat Completions adapter preserves an empty JSON-schema response when the provider reports `finish_reason: length`, including the raw response, usage, cost, and search metadata. Recognition processing can then use its existing bounded recovery: one retry from 900 to 2000 output tokens. A second empty response remains an analysis failure; other empty responses still raise `empty_answer`.
+The Chat Completions adapter preserves an empty JSON-schema response with `finish_reason: length` only when the caller explicitly enables `preserveEmptyStructuredTruncation` and handles recovery. The recognition service enables this option for its own calls to retain the raw response, usage, cost, and search metadata and use its existing bounded recovery: one retry from 900 to 2000 output tokens. A second empty response remains an analysis failure. Other callers, including measurements that share the recognition executor, retain `empty_answer` errors and their existing failure or retry behavior; ordinary text, JSON-object, and function-tool empty responses still raise `empty_answer` even with the option enabled.
 
 This does not substitute reasoning text for an answer or fabricate citations. OpenRouter requests continue to use only the OpenRouter key and retain `Source: OpenRouter API` labeling.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -217,6 +217,8 @@ export interface ProviderRunInput {
     name: string;
     schema: Record<string, unknown>;
   } | undefined;
+  /** Preserve empty token-limited JSON-schema responses only when the caller handles recovery. */
+  preserveEmptyStructuredTruncation?: boolean | undefined;
   structuredOutputTool?: {
     name: string;
     description: string;

--- a/src/product/recognition/recognition-service.ts
+++ b/src/product/recognition/recognition-service.ts
@@ -43,6 +43,7 @@ export interface RecognitionAnswerExecutor {
     modelSnapshot: ProductModelSnapshot;
     prompt: string;
     requestParameters: RecognitionRequestParameters;
+    preserveEmptyStructuredTruncation?: boolean | undefined;
     executionContext?: RecognitionExecutionContext | undefined;
     structuredOutput?: {
       name: string;
@@ -68,6 +69,7 @@ export class OpenRouterRecognitionAnswerExecutor implements RecognitionAnswerExe
     modelSnapshot: ProductModelSnapshot;
     prompt: string;
     requestParameters: RecognitionRequestParameters;
+    preserveEmptyStructuredTruncation?: boolean | undefined;
     executionContext?: RecognitionExecutionContext | undefined;
     structuredOutput?: {
       name: string;
@@ -88,6 +90,7 @@ export class OpenRouterRecognitionAnswerExecutor implements RecognitionAnswerExe
       temperature: input.requestParameters.temperature,
       webSearchEnabled: input.requestParameters.webSearchEnabled,
       webSearchMode: input.requestParameters.webSearchMode === "provider_native" ? "provider_native" : undefined,
+      preserveEmptyStructuredTruncation: input.preserveEmptyStructuredTruncation,
       ...(input.requestParameters.structuredOutputTransport === "function_tool"
         ? {
             structuredOutputTool: {
@@ -726,6 +729,7 @@ export class ProductRecognitionRunService {
         modelSnapshot: modelRun.modelSnapshot,
         prompt,
         requestParameters: parameters,
+        preserveEmptyStructuredTruncation: true,
         executionContext: {
           projectId: run.projectId,
           runId: run.id,
@@ -804,6 +808,7 @@ export class ProductRecognitionRunService {
               modelSnapshot: modelRun.modelSnapshot,
               prompt,
               requestParameters: retryParams,
+              preserveEmptyStructuredTruncation: true,
               executionContext: {
                 projectId: run.projectId,
                 runId: run.id,

--- a/src/providers/openai-compatible.ts
+++ b/src/providers/openai-compatible.ts
@@ -215,7 +215,11 @@ export class OpenAICompatibleProvider implements AnswerProvider {
       ? extractStructuredToolArguments(raw, input.structuredOutputTool.name)
       : undefined;
     const text = toolArguments || extractOpenAICompatibleText(raw);
-    if (!text) throw new ProviderRequestError({ code: "empty_answer", message: `Provider ${this.definition.id} returned an empty answer.` });
+    // 结构化输出可能在生成正文前耗尽额度；保留原始响应，交给调用方执行有上限的截断恢复。
+    const choices = asObject(raw)?.choices;
+    const firstChoice = asObject(Array.isArray(choices) ? choices[0] : undefined);
+    const emptyStructuredTruncation = input.responseJsonSchema && !outputTool && firstChoice?.finish_reason === "length";
+    if (!text && !emptyStructuredTruncation) throw new ProviderRequestError({ code: "empty_answer", message: `Provider ${this.definition.id} returned an empty answer.` });
     const structuredOutput = toolArguments
       ? { transport: "function_tool" as const, value: toolArguments }
       : input.responseJsonSchema

--- a/src/providers/openai-compatible.ts
+++ b/src/providers/openai-compatible.ts
@@ -215,10 +215,11 @@ export class OpenAICompatibleProvider implements AnswerProvider {
       ? extractStructuredToolArguments(raw, input.structuredOutputTool.name)
       : undefined;
     const text = toolArguments || extractOpenAICompatibleText(raw);
-    // 结构化输出可能在生成正文前耗尽额度；保留原始响应，交给调用方执行有上限的截断恢复。
+    // 仅在调用方负责截断恢复时保留空响应；其他调用方继续通过 empty_answer 重试。
     const choices = asObject(raw)?.choices;
     const firstChoice = asObject(Array.isArray(choices) ? choices[0] : undefined);
-    const emptyStructuredTruncation = input.responseJsonSchema && !outputTool && firstChoice?.finish_reason === "length";
+    const emptyStructuredTruncation = input.preserveEmptyStructuredTruncation === true
+      && input.responseJsonSchema && !outputTool && firstChoice?.finish_reason === "length";
     if (!text && !emptyStructuredTruncation) throw new ProviderRequestError({ code: "empty_answer", message: `Provider ${this.definition.id} returned an empty answer.` });
     const structuredOutput = toolArguments
       ? { transport: "function_tool" as const, value: toolArguments }

--- a/test/native-web-search.test.ts
+++ b/test/native-web-search.test.ts
@@ -479,3 +479,11 @@ test("custom OpenAI-compatible gateway uses chat completions offline and Respons
   assert.equal(captured[0]?.body.messages !== undefined, true);
   assert.deepEqual(captured[1]?.body.tools, [{ type: "web_search" }]);
 });
+
+test("empty unstructured answers remain errors even when token-limited", async () => {
+  const captured: CapturedRequest[] = [];
+  mockFetch({ choices: [{ finish_reason: "length", message: { content: null } }] }, captured);
+  const provider = new OpenAICompatibleProvider({ definition: definition("openrouter"), endpoint: "https://provider.example/chat/completions" });
+  await assert.rejects(provider.run(input()), { code: "empty_answer" });
+  assert.equal(captured.length, 1);
+});

--- a/test/native-web-search.test.ts
+++ b/test/native-web-search.test.ts
@@ -485,5 +485,55 @@ test("empty unstructured answers remain errors even when token-limited", async (
   mockFetch({ choices: [{ finish_reason: "length", message: { content: null } }] }, captured);
   const provider = new OpenAICompatibleProvider({ definition: definition("openrouter"), endpoint: "https://provider.example/chat/completions" });
   await assert.rejects(provider.run(input()), { code: "empty_answer" });
+  await assert.rejects(provider.run(input({ preserveEmptyStructuredTruncation: true })), { code: "empty_answer" });
+  assert.equal(captured.length, 2);
+});
+
+test("caller-managed truncation recovery is limited to JSON-schema responses", async () => {
+  const captured: CapturedRequest[] = [];
+  mockFetch({ choices: [{ finish_reason: "length", message: { content: null } }] }, captured);
+  const provider = new OpenAICompatibleProvider({ definition: definition("openrouter"), endpoint: "https://provider.example/chat/completions" });
+  const responseJsonSchema = { name: "result", schema: { type: "object" } };
+  for (const overrides of [
+    { responseJsonSchema },
+    { responseJsonSchema, preserveEmptyStructuredTruncation: false },
+    { responseFormat: "json_object" as const, preserveEmptyStructuredTruncation: true },
+    { responseJsonSchema, structuredOutputTool: { ...responseJsonSchema, description: "Return the result" }, preserveEmptyStructuredTruncation: true },
+  ]) {
+    await assert.rejects(provider.run(input(overrides)), { code: "empty_answer" });
+  }
+  assert.equal(captured.length, 4);
+});
+
+test("opted-in empty truncation preserves search evidence without using reasoning as the answer", async () => {
+  const captured: CapturedRequest[] = [];
+  const raw = {
+    choices: [{ finish_reason: "length", message: { content: null, reasoning: "Unfinished reasoning" } }],
+    usage: { prompt_tokens: 10, completion_tokens: 200, total_tokens: 210, cost: 0.001 },
+    openrouter_metadata: { pipeline: [{ type: "server_tools", data: { mode: "native" } }] },
+  };
+  mockFetch(raw, captured);
+  const provider = new OpenAICompatibleProvider({
+    definition: definition("openrouter", "OpenRouter"),
+    endpoint: "https://openrouter.ai/api/v1/chat/completions",
+    nativeWebSearch: openRouterSearch("server_tool"),
+  });
+  const result = await provider.run(input({
+    responseJsonSchema: { name: "result", schema: { type: "object" } },
+    preserveEmptyStructuredTruncation: true,
+    webSearchEnabled: true,
+    webSearchMode: "provider_native",
+  }));
+  assert.equal(result.text, "");
+  assert.deepEqual(result.structuredOutput, { transport: "response_json_schema", value: "" });
+  assert.deepEqual(result.rawProviderResponse, raw);
+  assert.deepEqual(result.tokenUsage, { input: 10, output: 200, total: 210 });
+  assert.equal(result.costUsd, 0.001);
+  assert.equal(result.sourceLabel, "Source: OpenRouter API");
+  assert.equal(result.search?.requested, true);
+  assert.equal(result.search?.used, true);
+  assert.equal(result.search?.executionMode, "native");
+  assert.deepEqual(result.citations, []);
   assert.equal(captured.length, 1);
+  assert.equal(captured[0]?.body.preserveEmptyStructuredTruncation, undefined);
 });

--- a/test/product-measurements.test.ts
+++ b/test/product-measurements.test.ts
@@ -86,6 +86,56 @@ async function settled(service: ProductMeasurementRunService, projectId: string,
   throw new Error("Measurement run did not settle.");
 }
 
+test("default measurement executor keeps empty token-limited responses as provider failures", async (t) => {
+  const previousKey = process.env.OPENROUTER_API_KEY;
+  process.env.OPENROUTER_API_KEY = "fixture-key";
+  t.after(() => {
+    if (previousKey === undefined) delete process.env.OPENROUTER_API_KEY;
+    else process.env.OPENROUTER_API_KEY = previousKey;
+  });
+  const requests: Array<{ maxTokens: number; schemaName: string }> = [];
+  t.mock.method(globalThis, "fetch", async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body));
+    assert.equal(new Headers(init?.headers).get("Authorization"), "Bearer fixture-key");
+    assert.equal(body.response_format?.type, "json_schema");
+    requests.push({ maxTokens: body.max_tokens, schemaName: body.response_format.json_schema.name });
+    return new Response(JSON.stringify({
+      choices: [{ finish_reason: "length", message: { content: null } }],
+      usage: { prompt_tokens: 100, completion_tokens: 900, total_tokens: 1000, cost: 0.001 },
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+  });
+
+  await withFixture(async (fixture) => {
+    const { project } = await ready(fixture, "target.example", [{ modelId: "phase5/off", webSearchMode: "off" }]);
+    const service = new ProductMeasurementRunService(fixture.projects, fixture.baselines, fixture.watchSets, fixture.store);
+    const run = await service.start(project.id);
+    const detail = await settled(service, project.id, run.id);
+    assert.equal(detail.run.status, "failed");
+    assert.equal(detail.run.plannedProbeCount, 3);
+    assert.equal(detail.run.completedProbeCount, 0);
+    assert.equal(detail.run.failedProbeCount, 3);
+    assert.deepEqual(requests.map((request) => request.maxTokens), [900, 900, 900]);
+    assert.deepEqual(requests.map((request) => request.schemaName), ["domain_recognition_result", "domain_recognition_result", "keyword_discovery_result"]);
+    const model = detail.modelRuns[0];
+    assert.ok(model);
+    assert.equal(model.status, "failed");
+    const probes = await fixture.store.listProbes(project.id, run.id, model.id);
+    assert.equal(probes.length, 3);
+    for (const probe of probes) {
+      const stored = await service.getProbe(project.id, run.id, model.id, probe.id);
+      assert.equal(stored.probe.status, "failed");
+      assert.equal(stored.probe.exclusionReason, "empty_answer");
+      assert.equal(stored.attempts.length, 1);
+      assert.equal(stored.attempts[0]?.status, "provider_failed");
+      assert.equal(stored.attempts[0]?.errorCode, "empty_answer");
+      assert.equal(stored.attempts[0]?.costState, "unknown");
+      assert.equal(stored.attempts[0]?.costUsd, null);
+      assert.equal(stored.domainResult, undefined);
+      assert.equal(stored.keywordResult, undefined);
+    }
+  });
+});
+
 test("T01/T02 keep keyword discovery neutral and domain probes independent", async () => {
   await withFixture(async (fixture) => {
     const { project } = await ready(fixture, "target.example", [{ modelId: "phase5/off", webSearchMode: "off" }]);

--- a/test/product-recognition.test.ts
+++ b/test/product-recognition.test.ts
@@ -14,11 +14,8 @@ import { ProductProjectFileStore } from "../src/product/projects/project-store.j
 import { RecognitionRunNotFoundError } from "../src/product/recognition/recognition-errors.js";
 import { handleProductRecognitionApi, handleProductRecognitionRetryApi } from "../src/product/recognition/recognition-http.js";
 import type { RecognitionAnswerExecutor } from "../src/product/recognition/recognition-service.js";
-import { ProductRecognitionRunService } from "../src/product/recognition/recognition-service.js";
+import { OpenRouterRecognitionAnswerExecutor, ProductRecognitionRunService } from "../src/product/recognition/recognition-service.js";
 import { ProductRecognitionFileStore } from "../src/product/recognition/recognition-store.js";
-import { OpenAICompatibleProvider } from "../src/providers/openai-compatible.js";
-import { PROVIDER_DEFINITIONS } from "../src/providers/catalog.js";
-import { domainRecognitionResponseSchema } from "../src/product/recognition/recognition-prompt.js";
 import { ProviderRequestError } from "../src/providers/provider-error.js";
 
 const fixtureModels: ProviderModelCatalogItem[] = [
@@ -884,11 +881,22 @@ test("re-analysis of truncated attempt preserves truncation evidence", async () 
 
 
 test("empty structured responses reach bounded truncation recovery through the provider adapter", async (t) => {
+  const previousKey = process.env.OPENROUTER_API_KEY;
+  process.env.OPENROUTER_API_KEY = "fixture-key";
+  t.after(() => {
+    if (previousKey === undefined) delete process.env.OPENROUTER_API_KEY;
+    else process.env.OPENROUTER_API_KEY = previousKey;
+  });
   for (const scenario of ["recovers", "still-truncated", "not-truncated"] as const) {
     await t.test(scenario, async (t) => {
       const budgets: number[] = [];
-      t.mock.method(globalThis, "fetch", async (_url: unknown, init: RequestInit) => {
+      t.mock.method(globalThis, "fetch", async (url: unknown, init: RequestInit) => {
         const body = JSON.parse(String(init.body));
+        assert.equal(String(url), "https://openrouter.ai/api/v1/chat/completions");
+        assert.equal(new Headers(init.headers).get("Authorization"), "Bearer fixture-key");
+        assert.equal(body.response_format.type, "json_schema");
+        assert.deepEqual(body.provider, { require_parameters: true });
+        assert.equal(body.preserveEmptyStructuredTruncation, undefined);
         budgets.push(body.max_tokens);
         const recovered = scenario === "recovers" && budgets.length === 2;
         return new Response(JSON.stringify({
@@ -899,22 +907,7 @@ test("empty structured responses reach bounded truncation recovery through the p
           usage: { prompt_tokens: 100, completion_tokens: body.max_tokens, total_tokens: 100 + body.max_tokens, cost: 0.001 },
         }), { status: 200, headers: { "Content-Type": "application/json" } });
       });
-      const definition = PROVIDER_DEFINITIONS.find((item) => item.id === "openrouter");
-      assert.ok(definition);
-      const provider = new OpenAICompatibleProvider({ definition, endpoint: "https://provider.example/chat/completions" });
-      const executor: RecognitionAnswerExecutor = {
-        execute(input) {
-          return provider.run({
-            model: input.modelSnapshot.modelId,
-            prompt: input.prompt,
-            apiKey: "fixture-key",
-            maxTokens: input.requestParameters.maxTokens,
-            temperature: 0,
-            webSearchEnabled: false,
-            responseJsonSchema: { name: "domain_recognition_result", schema: domainRecognitionResponseSchema },
-          });
-        },
-      };
+      const executor = new OpenRouterRecognitionAnswerExecutor();
       await withFixture(async (fixture) => {
         const project = await readyProject(fixture, "truncated.example", [{ modelId: "test/truncated", webSearchMode: "off" }]);
         const service = new ProductRecognitionRunService(fixture.projects, fixture.baselines, fixture.recognitionStore, executor);
@@ -937,6 +930,10 @@ test("empty structured responses reach bounded truncation recovery through the p
           assert.equal(initial.rawAnswer, "");
           assert.equal(initial.tokenUsage?.output, 900);
           assert.equal(initial.costUsd, 0.001);
+          assert.equal(initial.providerId, "openrouter");
+          assert.ok(initial.providerSearch && typeof initial.providerSearch === "object" && "requested" in initial.providerSearch);
+          assert.equal(initial.providerSearch.requested, false);
+          assert.equal(detail.archive?.result.analysisStatus, scenario === "recovers" ? "recognized" : "analysis_failed");
           assert.deepEqual(initial.rawProviderResponse, {
             choices: [{ finish_reason: "length", message: { content: null } }],
             usage: { prompt_tokens: 100, completion_tokens: 900, total_tokens: 1000, cost: 0.001 },

--- a/test/product-recognition.test.ts
+++ b/test/product-recognition.test.ts
@@ -16,6 +16,9 @@ import { handleProductRecognitionApi, handleProductRecognitionRetryApi } from ".
 import type { RecognitionAnswerExecutor } from "../src/product/recognition/recognition-service.js";
 import { ProductRecognitionRunService } from "../src/product/recognition/recognition-service.js";
 import { ProductRecognitionFileStore } from "../src/product/recognition/recognition-store.js";
+import { OpenAICompatibleProvider } from "../src/providers/openai-compatible.js";
+import { PROVIDER_DEFINITIONS } from "../src/providers/catalog.js";
+import { domainRecognitionResponseSchema } from "../src/product/recognition/recognition-prompt.js";
 import { ProviderRequestError } from "../src/providers/provider-error.js";
 
 const fixtureModels: ProviderModelCatalogItem[] = [
@@ -877,4 +880,69 @@ test("re-analysis of truncated attempt preserves truncation evidence", async () 
     assert.equal(retryAttempt.status, "completed");
     assert.ok(retryAttempt.requestParameters.maxTokens > 900, "Retry attempt should have higher maxTokens");
   });
+});
+
+
+test("empty structured responses reach bounded truncation recovery through the provider adapter", async (t) => {
+  for (const scenario of ["recovers", "still-truncated", "not-truncated"] as const) {
+    await t.test(scenario, async (t) => {
+      const budgets: number[] = [];
+      t.mock.method(globalThis, "fetch", async (_url: unknown, init: RequestInit) => {
+        const body = JSON.parse(String(init.body));
+        budgets.push(body.max_tokens);
+        const recovered = scenario === "recovers" && budgets.length === 2;
+        return new Response(JSON.stringify({
+          choices: [{
+            finish_reason: recovered || scenario === "not-truncated" ? "stop" : "length",
+            message: { content: recovered ? structuredAnswer(false) : null },
+          }],
+          usage: { prompt_tokens: 100, completion_tokens: body.max_tokens, total_tokens: 100 + body.max_tokens, cost: 0.001 },
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      });
+      const definition = PROVIDER_DEFINITIONS.find((item) => item.id === "openrouter");
+      assert.ok(definition);
+      const provider = new OpenAICompatibleProvider({ definition, endpoint: "https://provider.example/chat/completions" });
+      const executor: RecognitionAnswerExecutor = {
+        execute(input) {
+          return provider.run({
+            model: input.modelSnapshot.modelId,
+            prompt: input.prompt,
+            apiKey: "fixture-key",
+            maxTokens: input.requestParameters.maxTokens,
+            temperature: 0,
+            webSearchEnabled: false,
+            responseJsonSchema: { name: "domain_recognition_result", schema: domainRecognitionResponseSchema },
+          });
+        },
+      };
+      await withFixture(async (fixture) => {
+        const project = await readyProject(fixture, "truncated.example", [{ modelId: "test/truncated", webSearchMode: "off" }]);
+        const service = new ProductRecognitionRunService(fixture.projects, fixture.baselines, fixture.recognitionStore, executor);
+        const started = await service.start(project.id);
+        const result = await settled(service, project.id, started.run.id);
+        const modelRun = result.modelRuns[0];
+        assert.ok(modelRun);
+        const detail = await service.getModelRun(project.id, started.run.id, modelRun.id);
+        if (scenario === "not-truncated") {
+          assert.deepEqual(budgets, [900]);
+          assert.equal(modelRun.status, "failed");
+          assert.equal(detail.attempts[0]?.errorCode, "empty_answer");
+        } else {
+          assert.deepEqual(budgets, [900, 2000]);
+          assert.equal(modelRun.status, "completed");
+          assert.equal(detail.attempts.find((attempt) => attempt.attemptNumber === 2)?.status, scenario === "recovers" ? "completed" : "analysis_failed");
+          assert.equal(detail.attempts.length, 2);
+          const initial = detail.attempts.find((attempt) => attempt.attemptNumber === 1);
+          assert.ok(initial);
+          assert.equal(initial.rawAnswer, "");
+          assert.equal(initial.tokenUsage?.output, 900);
+          assert.equal(initial.costUsd, 0.001);
+          assert.deepEqual(initial.rawProviderResponse, {
+            choices: [{ finish_reason: "length", message: { content: null } }],
+            usage: { prompt_tokens: 100, completion_tokens: 900, total_tokens: 1000, cost: 0.001 },
+          });
+        }
+      });
+    });
+  }
 });

--- a/test/structured-provider-retry.test.ts
+++ b/test/structured-provider-retry.test.ts
@@ -1,0 +1,147 @@
+import test, { type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import type { Entity, MonitoringPrompt, PromptRun, ProviderDefinition } from "../src/core/types.js";
+import { CompetitorDiscovery } from "../src/analyzer/competitor-discovery.js";
+import { MonitoringPromptIntentClassifier } from "../src/prompts/monitoring-prompt-intent-classifier.js";
+import { OpenAICompatibleProvider } from "../src/providers/openai-compatible.js";
+
+const definition: ProviderDefinition = {
+  id: "structured-retry-test",
+  label: "Structured Retry Test",
+  sourceType: "api",
+  envKeys: [],
+  defaultModels: ["test-model"],
+  supportsJsonSchema: true,
+  supportsNativeCitations: false,
+  supportsWebSearch: false,
+  resultCaveat: "Test",
+};
+
+const target: Entity = { id: "example", type: "target", name: "Example", domain: "example.com", aliases: [] };
+const prompt: MonitoringPrompt = {
+  id: "question-a",
+  type: "brand",
+  topic: "brand question",
+  language: "en",
+  text: "What does Example provide?",
+  enabled: true,
+  auditCategory: "brand_awareness",
+  targetIncluded: true,
+};
+
+function retryFixture(t: TestContext, output: unknown): {
+  provider: OpenAICompatibleProvider;
+  budgets: number[];
+  responseFormats: string[];
+} {
+  const overrides = {
+    PROVIDER_RETRY_BASE_MS: "1",
+    PROVIDER_RUN_ATTEMPTS: "2",
+    PROVIDER_EMPTY_ANSWER_MAX_TOKENS: "4000",
+  };
+  const previous = Object.fromEntries(Object.keys(overrides).map((key) => [key, process.env[key]]));
+  Object.assign(process.env, overrides);
+  t.after(() => {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+  const budgets: number[] = [];
+  const responseFormats: string[] = [];
+  t.mock.method(globalThis, "fetch", async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body));
+    budgets.push(body.max_tokens);
+    responseFormats.push(body.response_format?.type);
+    const truncated = budgets.length === 1;
+    return new Response(JSON.stringify({
+      choices: [{
+        finish_reason: truncated ? "length" : "stop",
+        message: { content: truncated ? null : JSON.stringify(output) },
+      }],
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+  });
+  return {
+    provider: new OpenAICompatibleProvider({ definition, endpoint: "https://provider.example/chat/completions" }),
+    budgets,
+    responseFormats,
+  };
+}
+
+test("monitoring intent classification retries an empty token-limited JSON-schema response", async (t) => {
+  const fixture = retryFixture(t, {
+    questions: [{
+      questionId: prompt.id,
+      intents: ["product_understanding"],
+      candidateApplicable: false,
+      recommendationApplicable: false,
+      reason: "The question requests an explanation.",
+    }],
+  });
+  const result = await new MonitoringPromptIntentClassifier().classify({
+    target,
+    language: "en",
+    prompts: [prompt],
+    provider: fixture.provider,
+    model: "test-model",
+    apiKey: "fixture-key",
+  });
+
+  assert.deepEqual(fixture.budgets, [2400, 4000]);
+  assert.deepEqual(fixture.responseFormats, ["json_schema", "json_schema"]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.intentProfile?.status, "completed");
+  assert.deepEqual(result[0]?.intentProfile?.intents, ["product_understanding"]);
+});
+
+test("competitor discovery retries an empty token-limited JSON-schema response", async (t) => {
+  const competitor = {
+    name: "Other",
+    domain: "other.example",
+    reason: "An alternative for the same users.",
+    relationship: "direct_competitor",
+    confidence: 0.9,
+  };
+  const fixture = retryFixture(t, { competitors: [competitor] });
+  const completedRun: PromptRun = {
+    id: "run-a",
+    prompt,
+    target,
+    competitors: [],
+    providerId: definition.id,
+    model: "test-model",
+    webSearchEnabled: false,
+    sourceType: "api",
+    sourceLabel: "Source: Structured Retry Test API",
+    status: "completed",
+    startedAt: "2026-09-08T00:00:00.000Z",
+    finishedAt: "2026-09-08T00:00:01.000Z",
+    result: {
+      providerId: definition.id,
+      providerName: definition.label,
+      sourceType: "api",
+      sourceLabel: "Source: Structured Retry Test API",
+      resultCaveat: "Test",
+      model: "test-model",
+      modelVersion: "test-model",
+      text: "Other at other.example is an alternative to Example.",
+      citations: [],
+      webQueries: [],
+      latencyMs: 1,
+      createdAt: "2026-09-08T00:00:01.000Z",
+    },
+  };
+  const result = await new CompetitorDiscovery().discover({
+    target,
+    existingCompetitors: [],
+    runs: [completedRun],
+    language: "en",
+    provider: fixture.provider,
+    model: "test-model",
+    apiKey: "fixture-key",
+  });
+
+  assert.deepEqual(fixture.budgets, [900, 1800]);
+  assert.deepEqual(fixture.responseFormats, ["json_schema", "json_schema"]);
+  assert.deepEqual(result, [competitor]);
+});


### PR DESCRIPTION
OpenRouter 在生成结构化正文前耗尽输出额度时，可能返回空正文和 `finish_reason: length`。此前适配器直接抛出 `empty_answer`，使认知服务无法保存原始响应或执行已有的截断恢复。

本次由认知服务在初次和重试调用处显式启用 `preserveEmptyStructuredTruncation`，只在 JSON Schema 模式下放行明确因长度截断的空响应，保存原始响应、用量、费用及搜索信息，并按原有上限从 900 提高到 2000 tokens 重试一次。第二次仍为空时保留分析失败。共享执行器默认关闭此选项，测量服务继续保留原有失败状态及费用处理；其他调用方继续使用原有的 `empty_answer` 重试和预算提升。普通文本、JSON-object、function-tool 及非截断空回答仍报错。密钥路由、来源标注和默认额度保持原样，不以推理文本替代正文。

验证：
- 问题意图分类和竞品发现的新增回归测试先确认原 PR 失败；修复后分别按 2400 → 4000、900 → 1800 tokens 重试成功。
- 认知测试通过实际 `OpenRouterRecognitionAnswerExecutor`、ProviderCatalog 和适配器，覆盖恢复成功、持续截断后停止、非截断空回答不重试，以及 OpenRouter 请求配置和响应保存。
- 覆盖显式开关的适用边界、搜索元数据与费用保存、推理内容不替代正文。
- 测量服务通过默认执行器覆盖域名和关键词探测，空截断响应保持 `provider_failed / empty_answer`、原有费用状态及单次调用。
- `npm run self-check`：构建通过，225 项通过、10 项跳过、0 项失败。10 项跳过均因缺少真实 Provider 回放归档。

验证使用合成 Provider 响应，未重新执行付费 GEO 检测。2000 tokens 仍可能不足以完成部分模型的回答；本次确保有界恢复机制能执行，不保证所有模型成功。
